### PR TITLE
fix: copy `polkavm_guest.bc` to output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 *.dot
+*.bc
 .vscode/
 .DS_Store
 /*.sol

--- a/crates/pallet-contracts-pvm-llapi/build.rs
+++ b/crates/pallet-contracts-pvm-llapi/build.rs
@@ -35,8 +35,19 @@ fn main() {
     let bitcode_path = Path::new(&out_dir).join(lib);
     compile(bitcode_path.to_str().expect("$OUT_DIR should be UTF-8"));
 
-    let bitcode = fs::read(bitcode_path).expect("bitcode should have been built");
+    let bitcode = fs::read(&bitcode_path).expect("bitcode should have been built");
     let len = bitcode.len();
+
+    // Copying the polkavm_guest.bc file to the current directory
+    // for now, I will change this to copy to the output directory
+    // specified by the user.
+    // e.g:
+    // `cargo run Storage.sol -O3 --bin --output-dir './out'` 
+    // should copy the bitcode to `./out`. 
+    let current_dir = env::current_dir().expect("should be able to get current directory");
+    let output_path = current_dir.join(lib);
+    fs::copy(&bitcode_path, &output_path).expect("should be able to copy bitcode to current directory");
+
     let src_path = Path::new(&out_dir).join("polkavm_guest.rs");
     let src = format!("pub static BITCODE: &[u8; {len}] = include_bytes!(\"{lib}\");");
     fs::write(src_path, src).expect("should be able to write in $OUT_DIR");


### PR DESCRIPTION
Copying the generated `polkavm_guest.bc` file to the out put directory specified by the user.

### E.g 
The following command
 ````bash
 cargo run Storage.sol -O3 --bin --output-dir './out'
 ```` 
 Should additionally output `polkavm_guest.bc` to `./out` directory.
 
 ---
 
 ### Current behavior
 In this draft, I'm temporary copying it to `current` directory, I will implement the fix before the PR. 