### PR TITLE
feat: added npm workspaces support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 /*.s
 /llvm-project
 /llvm18.0
+node_modules
+artifacts
+tmp
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "root",
+    "private": true,
+    "scripts": {
+        "test:cli": "npm run test -w crates/solidity/src/tests/cli-tests"
+    },
+    "workspaces": [
+        "crates/solidity/src/tests/cli-tests"
+    ]
+}


### PR DESCRIPTION
## Description
  - Introduced `npm` workspaces to manage CLI tests from the root directory.
  - Enabled simplified npm dependency installation from the root directory. 
  - Updated `.gitignore` to align with the new workspace structure.

## Usage

From the root directory

To install repo npm packages, run:
```bash
npm install && npm fund
```

To run related tests, run:
```bash
npm run test:cli
```