### PR TITLE
feat: streamline bin updates during developement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,23 @@
-.PHONY : install test test-solidity test-cli test-integration clean
+.PHONY: install test test-solidity test-cli test-integration clean
 
-install :
-        cargo install --path crates/solidity && \
-        npm install && npm fund
+install:
+	cargo install --path crates/solidity && \
+	npm install && npm fund
 
-test : install test-integration test-cli test-solidity
+test: install test-integration test-cli test-solidity
 
-test-integration : install
-        cargo test --package revive-integration
+test-integration: install
+	cargo test --package revive-integration
 
-test-solidity : install
-        cargo test --package revive-solidity
+test-solidity: install
+	cargo test --package revive-solidity
 
-test-cli : install
-        npm run test:cli
+test-cli: install
+	npm run test:cli
 
-clean :
-        cargo clean && \
-        rm -rf node_modules && \
-        rm -rf crates/solidity/src/tests/cli-tests/artifacts && \
-        rm -f ~/.cargo/bin/zksolc && \
-        rm -f package-lock.json
- 
+clean:
+	cargo clean && \
+	rm -rf node_modules && \
+	rm -rf crates/solidity/src/tests/cli-tests/artifacts && \
+	rm -f ~/.cargo/bin/zksolc && \
+	rm -f package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,24 @@
-install:
-	cargo install --path crates/solidity && \
-	npm install && npm fund
+.PHONY : install test test-solidity test-cli test-integration clean
 
-test:
-	cargo install --path crates/solidity && \
-	npm install && npm fund && \
-	cargo test --manifest-path crates/solidity/Cargo.toml 
-	npm run test:cli
+install :
+        cargo install --path crates/solidity && \
+        npm install && npm fund
 
-test-solidity:
-	cargo test --manifest-path crates/solidity/Cargo.toml
+test : install test-integration test-cli test-solidity
 
-test-cli:
-	npm run test:cli
+test-integration : install
+        cargo test --package revive-integration
 
-clean:
-	cargo clean && \
-	rm -rf node_modules && \
-	rm -rf crates/solidity/src/tests/cli-tests/artifacts && \
-	rm -f ~/.cargo/bin/zksolc && \
-	rm -f package-lock.json
+test-solidity : install
+        cargo test --package revive-solidity
 
+test-cli : install
+        npm run test:cli
 
+clean :
+        cargo clean && \
+        rm -rf node_modules && \
+        rm -rf crates/solidity/src/tests/cli-tests/artifacts && \
+        rm -f ~/.cargo/bin/zksolc && \
+        rm -f package-lock.json
+ 

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ clean:
 	cargo clean && \
 	rm -rf node_modules && \
 	rm -rf crates/solidity/src/tests/cli-tests/artifacts && \
-	rm -f ~/.cargo/bin/zksolc && \
+	cargo uninstall revive-solidity && \
 	rm -f package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
-build:
-	cargo build && \
-	cp target/debug/zksolc ~/.cargo/bin/zksolc && \
+install:
+	cargo install --path crates/solidity && \
 	npm install && npm fund
 
-build-release:
-	cargo build --release && \
-	cp target/release/zksolc ~/.cargo/bin/zksolc && \
-	npm install && npm fund
+test:
+	cargo install --path crates/solidity && \
+	npm install && npm fund && \
+	cargo test --manifest-path crates/solidity/Cargo.toml 
+	npm run test:cli
+
+test-solidity:
+	cargo test --manifest-path crates/solidity/Cargo.toml
+
+test-cli:
+	npm run test:cli
 
 clean:
 	cargo clean && \
@@ -15,5 +21,4 @@ clean:
 	rm -f ~/.cargo/bin/zksolc && \
 	rm -f package-lock.json
 
-test:
-	npm run test:cli
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+build:
+	cargo build && \
+	cp target/debug/zksolc ~/.cargo/bin/zksolc && \
+	npm install && npm fund
+
+build-release:
+	cargo build --release && \
+	cp target/release/zksolc ~/.cargo/bin/zksolc && \
+	npm install && npm fund
+
+clean:
+	cargo clean && \
+	rm -rf node_modules && \
+	rm -rf crates/solidity/src/tests/cli-tests/artifacts && \
+	rm -f ~/.cargo/bin/zksolc && \
+	rm -f package-lock.json
+
+test:
+	npm run test:cli

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The project is in a very early PoC phase. Don't yet expect the produced code to 
 - [ ] Use `drink` for integration tests once we have 64bit support in PolkaVM
 - [x] Use PolkaVM allocator for heap space
 - [ ] Exercice `schlau` and possibly `smart-bench` benchmark cases
-- [ ] Tests currently rely on the binary being in $PATH, which is very annoying and requires `cargo install` all the times
+- [x] Tests currently rely on the binary being in $PATH, which is very annoying and requires `cargo install` all the times
 - [ ] Define how to do deployments
 - [ ] Calling conventions for calling other contracts
 - [ ] Runtime environment isn't fully figured out; implement all EVM builtins


### PR DESCRIPTION
## Description
This PR introduces a way for the `zksolc` binary to automatically be updated/copied to `.cargo/bin` after each build to resolves the issue of having to manually update the $PATH or each time keep running `cargo install --path crates/solidity`, which was a recurring annoyance during testing and development.

## Usage

To install the project dependencies, run:
```bash
make install
```

To clean the project directory from all build artifacts and dependencies, run:
```bash
make clean
```
To run integration tests, use
```bash
make test-integration
```

To run the project's tests, ( both Rust and npm tests ) use:
```bash
make test
```

To run only solidity crate test, use:
```bash
make test-solidity
```

To run only the CLI tests, use:
```bash
make test-cli
```