### PR TITLE
chore: added code formating target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install-npm:
 	npm install && npm fund
 
 format:
-	cargo fmt --all
+	cargo fmt --all --check
 
 test: format install test-integration test-cli test-solidity
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test test-solidity test-cli test-integration clean
+.PHONY: install format test test-solidity test-cli test-integration clean
 
 install: install-bin install-npm
 
@@ -8,7 +8,10 @@ install-bin:
 install-npm:
 	npm install && npm fund
 
-test: install test-integration test-cli test-solidity
+format:
+	cargo fmt --all
+
+test: format install test-integration test-cli test-solidity
 
 test-integration: install-bin
 	cargo test --package revive-integration


### PR DESCRIPTION
## Description
Since 'make test' is frequently used during development, adding the codebase formatting target as a prerequisite to it, will help maintain consistency in the codebase more easily.

### Usage
During testing, formatting will automatically be applied 
```bash
make test
```
#### Or

If you only want to format the codebase without running the tests, you should just run:
```bash
make format
```