### PR TITLE
Test infrastructure for revive-wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ evm-interpreter = { git = "https://github.com/xermicus/evm.git", branch = "separ
 git = "https://github.com/TheDan64/inkwell.git"
 rev = "6c0fb56b3554e939f9ca61b465043d6a84fb7b95"
 default-features = false
-features = ["serde", "llvm18-0", "no-libffi-linking", "target-riscv"]
+features = ["serde", "llvm18-0-no-llvm-linking", "target-riscv"]
 
 [profile.benchmark]
 inherits = "release"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install-bin:
 	cargo install --path crates/solidity
 
 install-wasm:
-	cargo install --target wasm32-unknown-emscripten --path crates/solidity
+	RUSTFLAGS='-Clink-arg=-sEXPORTED_FUNCTIONS=_main,_free,_malloc -Clink-arg=-sNO_INVOKE_RUN -Clink-arg=-sEXIT_RUNTIME -Clink-arg=-sINITIAL_MEMORY=64MB -Clink-arg=-sALLOW_MEMORY_GROWTH -Clink-arg=-sEXPORTED_RUNTIME_METHODS=FS,callMain -Clink-arg=-sMODULARIZE -Clink-arg=-sEXPORT_ES6' cargo install --target wasm32-unknown-emscripten --path crates/solidity
 
 install-npm:
 	npm install && npm fund

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ install: install-bin install-npm
 install-bin:
 	cargo install --path crates/solidity
 
+install-wasm:
+	cargo install --target wasm32-unknown-emscripten --path crates/solidity
+
 install-npm:
 	npm install && npm fund
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 .PHONY: install format test test-solidity test-cli test-integration test-workspace clean docs docs-build
 
+ifeq ($(strip $(WASM_INSTALL_PREFIX)),)
+WASM_INSTALL_PREFIX=$(shell pwd)
+endif
+$(info "WASM_INSTALL_PREFIX=$(WASM_INSTALL_PREFIX))
+
 install: install-bin install-npm
 
 install-bin:
 	cargo install --path crates/solidity
 
 install-wasm:
-	RUSTFLAGS='-Clink-arg=-sEXPORTED_FUNCTIONS=_main,_free,_malloc -Clink-arg=-sNO_INVOKE_RUN -Clink-arg=-sEXIT_RUNTIME -Clink-arg=-sINITIAL_MEMORY=64MB -Clink-arg=-sALLOW_MEMORY_GROWTH -Clink-arg=-sEXPORTED_RUNTIME_METHODS=FS,callMain -Clink-arg=-sMODULARIZE -Clink-arg=-sEXPORT_ES6' cargo install --target wasm32-unknown-emscripten --path crates/solidity
+	RUSTFLAGS='-Clink-arg=-sEXPORTED_FUNCTIONS=_main,_free,_malloc -Clink-arg=-sNO_INVOKE_RUN -Clink-arg=-sEXIT_RUNTIME -Clink-arg=-sINITIAL_MEMORY=64MB -Clink-arg=-sALLOW_MEMORY_GROWTH -Clink-arg=-sEXPORTED_RUNTIME_METHODS=FS,callMain -Clink-arg=-sMODULARIZE -Clink-arg=-sEXPORT_ES6' cargo install --root $(WASM_INSTALL_PREFIX) --target wasm32-unknown-emscripten --path crates/solidity
+	echo '{ "type": "module" }' > $(WASM_INSTALL_PREFIX)/target/wasm32-unknown-emscripten/release/package.json
 
 install-npm:
 	npm install && npm fund

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ test-workspace: install
 test-cli: install
 	npm run test:cli
 
+test-wasm: install-wasm
+	npm run test:wasm
+
 bench-prepare: install-bin
 	cargo criterion --bench prepare --features bench-evm,bench-pvm --message-format=json \
 	| criterion-table > crates/benchmarks/PREPARE.md

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ resolc --version
 
 `revive` requires a build of LLVM 18.1.4 or later including `compiler-rt`. Use the provided [build-llvm.sh](build-llvm.sh) build script to compile a compatible LLVM build locally in `$PWD/llvm18.0` (don't forget to add that to `$PATH` afterwards). 
 
+### Wasm cross-compilation
+
+Install [emscripten](https://emscripten.org/docs/getting_started/downloads.html)
+```bash
+export EMSDK_ROOT=<PATH_TO_EMSCRIPTEN_SDK>
+bash emscripten-build-llvm.sh
+export LLVM_LINK_PREFIX=${PWD}/llvm18.0-emscripten
+make install-wasm
+```
+
 ### Development
 
 Please consult the [Makefile](Makefile) targets to learn how to run tests and benchmarks. 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ export EMSDK_ROOT=<PATH_TO_EMSCRIPTEN_SDK>
 bash emscripten-build-llvm.sh
 export LLVM_LINK_PREFIX=${PWD}/llvm18.0-emscripten
 make install-wasm
+echo '{ "type": "module" }' > ${PWD}/target/wasm32-unknown-emscripten/release/package.json
 ```
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ export EMSDK_ROOT=<PATH_TO_EMSCRIPTEN_SDK>
 bash emscripten-build-llvm.sh
 export LLVM_LINK_PREFIX=${PWD}/llvm18.0-emscripten
 make install-wasm
-echo '{ "type": "module" }' > ${PWD}/target/wasm32-unknown-emscripten/release/package.json
 ```
 
 ### Development

--- a/build-llvm.sh
+++ b/build-llvm.sh
@@ -15,64 +15,9 @@ fi
 # Build LLVM, clang
 cd llvm-project
 
-EMSDK_ROOT=/Users/smiasojed/Development/emsdk
-
-source ${EMSDK_ROOT}/emsdk_env.sh
-
-LLVM_SRC=$(pwd)
-BUILD=${LLVM_SRC}/build
-BUILD=$(realpath "$BUILD")
-LLVM_BUILD=$BUILD/llvm-wasm
-LLVM_NATIVE=$BUILD/llvm-native
-
-# Cross compiling llvm needs a native build of "llvm-tblgen" and "clang-tblgen"
-if [ ! -d $LLVM_NATIVE/ ]; then
-    cmake -G Ninja \
-        -S $LLVM_SRC/llvm/ \
-        -B $LLVM_NATIVE/ \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DLLVM_TARGETS_TO_BUILD=WebAssembly \
-        -DLLVM_ENABLE_PROJECTS="clang" \
-		-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
-fi
-cmake --build $LLVM_NATIVE/ -- llvm-tblgen clang-tblgen
-
-if [ ! -d $LLVM_BUILD/ ]; then
-	EMCC_DEBUG=2 \
-    CXXFLAGS="-Dwait4=__syscall_wait4" \
-	LDFLAGS="-s NO_INVOKE_RUN -s EXIT_RUNTIME -s INITIAL_MEMORY=64MB -s ALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=FS,callMain -s MODULARIZE -s EXPORT_ES6 -s WASM_BIGINT" \
-	emcmake cmake -G Ninja \
-        -S $LLVM_SRC/llvm/ \
-        -B $LLVM_BUILD/ \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DLLVM_TARGETS_TO_BUILD='RISCV' \
-        -DLLVM_ENABLE_PROJECTS="clang;lld" \
-        -DLLVM_ENABLE_DUMP=OFF \
-        -DLLVM_ENABLE_ASSERTIONS=OFF \
-        -DLLVM_ENABLE_EXPENSIVE_CHECKS=OFF \
-        -DLLVM_ENABLE_BACKTRACES=OFF \
-        -DLLVM_BUILD_TOOLS=OFF \
-        -DLLVM_ENABLE_THREADS=OFF \
-        -DLLVM_BUILD_LLVM_DYLIB=OFF \
-        -DLLVM_INCLUDE_TESTS=OFF \
-		-DLLVM_ENABLE_TERMINFO=Off \
-  		-DLLVM_ENABLE_LIBXML2=Off \
-  		-DLLVM_ENABLE_ZLIB=Off \
-		-DLLVM_ENABLE_ZSTD=Off \
-        -DLLVM_TABLEGEN=$LLVM_NATIVE/bin/llvm-tblgen \
-        -DCLANG_TABLEGEN=$LLVM_NATIVE/bin/clang-tblgen \
-		-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/wasm
-fi
-
-cmake --build $LLVM_BUILD/
-cmake --install $LLVM_BUILD/
-
-# Build LLVM, clang, RISCV target
-LLVM_NATIVE_RISCV_BUILD=$BUILD/llvm-native-riscv
-cmake -G Ninja \
-  -S $LLVM_SRC/llvm/ \
-  -B $LLVM_NATIVE_RISCV_BUILD/ \
-  -DLLVM_ENABLE_ASSERTIONS=On \
+mkdir -p build
+cd build
+cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On \
   -DLLVM_ENABLE_TERMINFO=Off \
   -DLLVM_ENABLE_LIBXML2=Off \
   -DLLVM_ENABLE_ZLIB=Off \
@@ -80,13 +25,17 @@ cmake -G Ninja \
   -DLLVM_TARGETS_TO_BUILD='RISCV' \
   -DLLVM_ENABLE_ZSTD=Off \
   -DCMAKE_BUILD_TYPE=MinSizeRel \
-  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+	../llvm
 
-cmake --build $LLVM_NATIVE_RISCV_BUILD/
-cmake --install $LLVM_NATIVE_RISCV_BUILD/
+ninja
+ninja install
+
 
 # Build compiler builtins
-COMPILER_RT_BUILD=$BUILD/compiler_rt
+cd ../compiler-rt
+mkdir -p build
+cd build
 
 build_compiler_rt() {
 	case "$1" in
@@ -97,8 +46,6 @@ build_compiler_rt() {
 	CFLAGS="--target=riscv${1} -march=rv${1}em -mabi=${TARGET_ABI} -mcpu=generic-rv${1} -nostdlib -nodefaultlibs"
 
 	cmake -G Ninja \
-	  -S $LLVM_SRC/compiler-rt/ \
-      -B $COMPILER_RT_BUILD/ \
 	  -DCMAKE_BUILD_TYPE=Release \
 	  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
 	  -DCOMPILER_RT_BUILD_BUILTINS=ON \
@@ -123,10 +70,11 @@ build_compiler_rt() {
 	  -DCOMPILER_RT_TEST_COMPILER=${INSTALL_DIR}/bin/clang \
 	  -DCMAKE_CXX_FLAGS="${CFLAGS}" \
 	  -DCMAKE_SYSTEM_NAME=unknown \
-	  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+	  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+	  ..
 	
-	cmake --build $COMPILER_RT_BUILD/
-	cmake --install $COMPILER_RT_BUILD/
+	ninja
+	ninja install
 }
 
 build_compiler_rt 32

--- a/build-llvm.sh
+++ b/build-llvm.sh
@@ -15,9 +15,64 @@ fi
 # Build LLVM, clang
 cd llvm-project
 
-mkdir -p build
-cd build
-cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On \
+EMSDK_ROOT=/Users/smiasojed/Development/emsdk
+
+source ${EMSDK_ROOT}/emsdk_env.sh
+
+LLVM_SRC=$(pwd)
+BUILD=${LLVM_SRC}/build
+BUILD=$(realpath "$BUILD")
+LLVM_BUILD=$BUILD/llvm-wasm
+LLVM_NATIVE=$BUILD/llvm-native
+
+# Cross compiling llvm needs a native build of "llvm-tblgen" and "clang-tblgen"
+if [ ! -d $LLVM_NATIVE/ ]; then
+    cmake -G Ninja \
+        -S $LLVM_SRC/llvm/ \
+        -B $LLVM_NATIVE/ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD=WebAssembly \
+        -DLLVM_ENABLE_PROJECTS="clang" \
+		-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+fi
+cmake --build $LLVM_NATIVE/ -- llvm-tblgen clang-tblgen
+
+if [ ! -d $LLVM_BUILD/ ]; then
+	EMCC_DEBUG=2 \
+    CXXFLAGS="-Dwait4=__syscall_wait4" \
+	LDFLAGS="-s NO_INVOKE_RUN -s EXIT_RUNTIME -s INITIAL_MEMORY=64MB -s ALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=FS,callMain -s MODULARIZE -s EXPORT_ES6 -s WASM_BIGINT" \
+	emcmake cmake -G Ninja \
+        -S $LLVM_SRC/llvm/ \
+        -B $LLVM_BUILD/ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD='RISCV' \
+        -DLLVM_ENABLE_PROJECTS="clang;lld" \
+        -DLLVM_ENABLE_DUMP=OFF \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_EXPENSIVE_CHECKS=OFF \
+        -DLLVM_ENABLE_BACKTRACES=OFF \
+        -DLLVM_BUILD_TOOLS=OFF \
+        -DLLVM_ENABLE_THREADS=OFF \
+        -DLLVM_BUILD_LLVM_DYLIB=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+		-DLLVM_ENABLE_TERMINFO=Off \
+  		-DLLVM_ENABLE_LIBXML2=Off \
+  		-DLLVM_ENABLE_ZLIB=Off \
+		-DLLVM_ENABLE_ZSTD=Off \
+        -DLLVM_TABLEGEN=$LLVM_NATIVE/bin/llvm-tblgen \
+        -DCLANG_TABLEGEN=$LLVM_NATIVE/bin/clang-tblgen \
+		-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/wasm
+fi
+
+cmake --build $LLVM_BUILD/
+cmake --install $LLVM_BUILD/
+
+# Build LLVM, clang, RISCV target
+LLVM_NATIVE_RISCV_BUILD=$BUILD/llvm-native-riscv
+cmake -G Ninja \
+  -S $LLVM_SRC/llvm/ \
+  -B $LLVM_NATIVE_RISCV_BUILD/ \
+  -DLLVM_ENABLE_ASSERTIONS=On \
   -DLLVM_ENABLE_TERMINFO=Off \
   -DLLVM_ENABLE_LIBXML2=Off \
   -DLLVM_ENABLE_ZLIB=Off \
@@ -25,17 +80,13 @@ cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On \
   -DLLVM_TARGETS_TO_BUILD='RISCV' \
   -DLLVM_ENABLE_ZSTD=Off \
   -DCMAKE_BUILD_TYPE=MinSizeRel \
-  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
-	../llvm
+  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
 
-ninja
-ninja install
-
+cmake --build $LLVM_NATIVE_RISCV_BUILD/
+cmake --install $LLVM_NATIVE_RISCV_BUILD/
 
 # Build compiler builtins
-cd ../compiler-rt
-mkdir -p build
-cd build
+COMPILER_RT_BUILD=$BUILD/compiler_rt
 
 build_compiler_rt() {
 	case "$1" in
@@ -46,6 +97,8 @@ build_compiler_rt() {
 	CFLAGS="--target=riscv${1} -march=rv${1}em -mabi=${TARGET_ABI} -mcpu=generic-rv${1} -nostdlib -nodefaultlibs"
 
 	cmake -G Ninja \
+	  -S $LLVM_SRC/compiler-rt/ \
+      -B $COMPILER_RT_BUILD/ \
 	  -DCMAKE_BUILD_TYPE=Release \
 	  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
 	  -DCOMPILER_RT_BUILD_BUILTINS=ON \
@@ -70,11 +123,10 @@ build_compiler_rt() {
 	  -DCOMPILER_RT_TEST_COMPILER=${INSTALL_DIR}/bin/clang \
 	  -DCMAKE_CXX_FLAGS="${CFLAGS}" \
 	  -DCMAKE_SYSTEM_NAME=unknown \
-	  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-	  ..
+	  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
 	
-	ninja
-	ninja install
+	cmake --build $COMPILER_RT_BUILD/
+	cmake --install $COMPILER_RT_BUILD/
 }
 
 build_compiler_rt 32

--- a/crates/lld-sys/build.rs
+++ b/crates/lld-sys/build.rs
@@ -1,5 +1,16 @@
-fn llvm_config(arg: &str) -> String {
-    let output = std::process::Command::new("llvm-config")
+use std::{env, path::{Path, PathBuf}};
+
+const LLVM_LINK_PREFIX: &str = "LLVM_LINK_PREFIX";
+
+fn locate_llvm_config() -> PathBuf {
+    let prefix = env::var_os(LLVM_LINK_PREFIX)
+        .map(|p| PathBuf::from(p).join("bin"))
+        .unwrap_or_default();
+    prefix.join("llvm-config")
+}
+
+fn llvm_config(llvm_config_path: &Path, arg: &str) -> String {
+    let output = std::process::Command::new(llvm_config_path)
         .args([arg])
         .output()
         .unwrap_or_else(|_| panic!("`llvm-config {arg}` failed"));
@@ -8,8 +19,8 @@ fn llvm_config(arg: &str) -> String {
         .unwrap_or_else(|_| panic!("output of `llvm-config {arg}` should be utf8"))
 }
 
-fn set_rustc_link_flags() {
-    println!("cargo:rustc-link-search=native={}", llvm_config("--libdir"));
+fn set_rustc_link_flags(llvm_config_path: &Path) {
+    println!("cargo:rustc-link-search=native={}", llvm_config(llvm_config_path, "--libdir"));
 
     for lib in [
         "lldELF",
@@ -21,6 +32,97 @@ fn set_rustc_link_flags() {
         "LLVMLTO",
         "LLVMTargetParser",
         "LLVMBinaryFormat",
+        "LLVMDemangle",
+        // Required by `llvm-sys`. Linking with `llvm-sys` is not allowed, as it needs to use `llvm-config`.
+        "LLVMWindowsManifest",
+        "LLVMXRay",
+        "LLVMLibDriver",
+        "LLVMDlltoolDriver",
+        "LLVMTextAPIBinaryReader",
+        "LLVMCoverage",
+        "LLVMLineEditor",
+        "LLVMRISCVTargetMCA",
+        "LLVMRISCVDisassembler",
+        "LLVMRISCVAsmParser",
+        "LLVMRISCVCodeGen",
+        "LLVMRISCVDesc",
+        "LLVMRISCVInfo",
+        "LLVMOrcDebugging",
+        "LLVMOrcJIT",
+        "LLVMWindowsDriver",
+        "LLVMMCJIT",
+        "LLVMJITLink",
+        "LLVMInterpreter",
+        "LLVMExecutionEngine",
+        "LLVMRuntimeDyld",
+        "LLVMOrcTargetProcess",
+        "LLVMOrcShared",
+        "LLVMDWP",
+        "LLVMDebugInfoLogicalView",
+        "LLVMDebugInfoGSYM",
+        "LLVMOption",
+        "LLVMObjectYAML",
+        "LLVMObjCopy",
+        "LLVMMCA",
+        "LLVMMCDisassembler",
+        "LLVMLTO",
+        "LLVMPasses",
+        "LLVMHipStdPar",
+        "LLVMCFGuard",
+        "LLVMCoroutines",
+        "LLVMipo",
+        "LLVMVectorize",
+        "LLVMLinker",
+        "LLVMInstrumentation",
+        "LLVMFrontendOpenMP",
+        "LLVMFrontendOffloading",
+        "LLVMFrontendOpenACC",
+        "LLVMFrontendHLSL",
+        "LLVMFrontendDriver",
+        "LLVMExtensions",
+        "LLVMDWARFLinkerParallel",
+        "LLVMDWARFLinkerClassic",
+        "LLVMDWARFLinker",
+        "LLVMGlobalISel",
+        "LLVMMIRParser",
+        "LLVMAsmPrinter",
+        "LLVMSelectionDAG",
+        "LLVMCodeGen",
+        "LLVMTarget",
+        "LLVMObjCARCOpts",
+        "LLVMCodeGenTypes",
+        "LLVMIRPrinter",
+        "LLVMInterfaceStub",
+        "LLVMFileCheck",
+        "LLVMFuzzMutate",
+        "LLVMScalarOpts",
+        "LLVMInstCombine",
+        "LLVMAggressiveInstCombine",
+        "LLVMTransformUtils",
+        "LLVMBitWriter",
+        "LLVMAnalysis",
+        "LLVMProfileData",
+        "LLVMSymbolize",
+        "LLVMDebugInfoBTF",
+        "LLVMDebugInfoPDB",
+        "LLVMDebugInfoMSF",
+        "LLVMDebugInfoDWARF",
+        "LLVMObject",
+        "LLVMTextAPI",
+        "LLVMMCParser",
+        "LLVMIRReader",
+        "LLVMAsmParser",
+        "LLVMMC",
+        "LLVMDebugInfoCodeView",
+        "LLVMBitReader",
+        "LLVMFuzzerCLI",
+        "LLVMCore",
+        "LLVMRemarks",
+        "LLVMBitstreamReader",
+        "LLVMBinaryFormat",
+        "LLVMTargetParser",
+        "LLVMTableGen",
+        "LLVMSupport",
         "LLVMDemangle",
     ] {
         println!("cargo:rustc-link-lib=static={lib}");
@@ -34,7 +136,11 @@ fn set_rustc_link_flags() {
 }
 
 fn main() {
-    llvm_config("--cxxflags")
+    println!("cargo:rerun-if-env-changed={}", LLVM_LINK_PREFIX);
+
+    let llvm_config_path = locate_llvm_config();
+
+    llvm_config(&llvm_config_path, "--cxxflags")
         .split_whitespace()
         .fold(&mut cc::Build::new(), |builder, flag| builder.flag(flag))
         .flag("-Wno-unused-parameter")
@@ -42,7 +148,7 @@ fn main() {
         .file("src/linker.cpp")
         .compile("liblinker.a");
 
-    set_rustc_link_flags();
+       set_rustc_link_flags(&llvm_config_path);
 
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/emscripten-build-llvm.sh
+++ b/emscripten-build-llvm.sh
@@ -42,7 +42,7 @@ cmake --build $LLVM_NATIVE/ -- llvm-tblgen clang-tblgen llvm-config
 if [ ! -d $LLVM_WASM/ ]; then
 	EMCC_DEBUG=2 \
     CXXFLAGS="-Dwait4=__syscall_wait4" \
-	LDFLAGS="-s NO_INVOKE_RUN -s EXIT_RUNTIME -s INITIAL_MEMORY=64MB -s ALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=FS,callMain -s MODULARIZE -s EXPORT_ES6 -s WASM_BIGINT" \
+	LDFLAGS="-lnodefs.js -s NO_INVOKE_RUN -s EXIT_RUNTIME -s INITIAL_MEMORY=64MB -s ALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=FS,callMain,NODEFS -s MODULARIZE -s EXPORT_ES6 -s WASM_BIGINT" \
 	emcmake cmake -G Ninja \
         -S $LLVM_SRC/llvm/ \
         -B $LLVM_WASM/ \

--- a/emscripten-build-llvm.sh
+++ b/emscripten-build-llvm.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTALL_DIR="${PWD}/llvm18.0-emscripten"
+mkdir -p ${INSTALL_DIR}
+
+
+# Clone LLVM 18 (any revision after commit bd32aaa is supposed to work)
+if [ ! -d "llvm-project" ]; then
+  git clone --depth 1 --branch release/18.x https://github.com/llvm/llvm-project.git
+fi
+
+# Build LLVM, clang
+cd llvm-project
+
+# Check if EMSDK_ROOT is defined
+if [ -z "$EMSDK_ROOT" ]; then
+    echo "Error: EMSDK_ROOT is not defined."
+    echo "Please set the EMSDK_ROOT environment variable to the root directory of your Emscripten SDK."
+    exit 1
+fi
+
+source ${EMSDK_ROOT}/emsdk_env.sh
+
+LLVM_SRC=$(pwd)
+LLVM_SRC=$(realpath "$LLVM_SRC")
+LLVM_NATIVE=$LLVM_SRC/build-native
+LLVM_WASM=$LLVM_SRC/build-wasm
+
+# Cross compiling llvm needs a native build of "llvm-tblgen" and "clang-tblgen"
+if [ ! -d $LLVM_NATIVE/ ]; then
+    cmake -G Ninja \
+        -S $LLVM_SRC/llvm/ \
+        -B $LLVM_NATIVE/ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD=WebAssembly \
+        -DLLVM_ENABLE_PROJECTS="clang"
+fi
+cmake --build $LLVM_NATIVE/ -- llvm-tblgen clang-tblgen llvm-config
+
+if [ ! -d $LLVM_WASM/ ]; then
+	EMCC_DEBUG=2 \
+    CXXFLAGS="-Dwait4=__syscall_wait4" \
+	LDFLAGS="-s NO_INVOKE_RUN -s EXIT_RUNTIME -s INITIAL_MEMORY=64MB -s ALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=FS,callMain -s MODULARIZE -s EXPORT_ES6 -s WASM_BIGINT" \
+	emcmake cmake -G Ninja \
+        -S $LLVM_SRC/llvm/ \
+        -B $LLVM_WASM/ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD='RISCV' \
+        -DLLVM_ENABLE_PROJECTS="clang;lld" \
+        -DLLVM_ENABLE_DUMP=OFF \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_EXPENSIVE_CHECKS=OFF \
+        -DLLVM_ENABLE_BACKTRACES=OFF \
+        -DLLVM_BUILD_TOOLS=OFF \
+        -DLLVM_ENABLE_THREADS=OFF \
+        -DLLVM_BUILD_LLVM_DYLIB=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+		-DLLVM_ENABLE_TERMINFO=Off \
+  		-DLLVM_ENABLE_LIBXML2=Off \
+  		-DLLVM_ENABLE_ZLIB=Off \
+		-DLLVM_ENABLE_ZSTD=Off \
+        -DLLVM_TABLEGEN=$LLVM_NATIVE/bin/llvm-tblgen \
+        -DCLANG_TABLEGEN=$LLVM_NATIVE/bin/clang-tblgen \
+		-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/
+fi
+
+cmake --build $LLVM_WASM/
+cmake --install $LLVM_WASM/
+
+cp $LLVM_NATIVE/bin/llvm-config $INSTALL_DIR/bin
+
+echo ""
+echo "success"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
     "name": "root",
     "private": true,
     "scripts": {
-        "test:cli": "npm run test -w crates/solidity/src/tests/cli-tests"
+        "test:cli": "npm run test -w crates/solidity/src/tests/cli-tests",
+        "test:wasm": "npm run test -w revive-wasm/tests/wasm-tests"
     },
     "workspaces": [
-        "crates/solidity/src/tests/cli-tests"
+        "crates/solidity/src/tests/cli-tests",
+        "revive-wasm/tests/wasm-tests"
     ]
 }

--- a/revive-wasm/tests/wasm-tests/jest.config.js
+++ b/revive-wasm/tests/wasm-tests/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: "node"
+};
+

--- a/revive-wasm/tests/wasm-tests/package.json
+++ b/revive-wasm/tests/wasm-tests/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "wasm-tests",
+    "version": "1.0.0",
+    "title": "resolc CLI Tests",
+    "description": "Auto tests for verifying resolc Webassembly build",
+    "repository": "https://github.com/xermicus/revive",
+    "main": "index.js",
+    "private": true,
+    "scripts": {
+      "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest --verbose --testPathPattern="
+    },
+    "keywords": [],
+    "author": "Matter Labs",
+    "contributors": [
+      "matt.aw@parity.io"
+    ],
+    "license": "MIT",
+    "devDependencies": {
+      "@types/jest": "^29.5.11",
+      "@types/shelljs": "^0.8.15",
+      "jest": "^29.7.0",
+      "shelljs": "^0.8.5",
+      "ts-jest": "^29.1.1",
+      "typescript": "^5.3.3"
+    }
+  }

--- a/revive-wasm/tests/wasm-tests/src/entities.ts
+++ b/revive-wasm/tests/wasm-tests/src/entities.ts
@@ -1,0 +1,27 @@
+import * as path from 'path';
+
+const outputDir = 'artifacts';
+const binExtension = ':C.pvm';
+const asmExtension = ':C.pvmasm';
+const contractSolFilename = 'contract.sol';
+const contractYulFilename = 'contract.yul';
+const pathToOutputDir = path.join(__dirname, '..', outputDir);
+const pathToContracts = path.join(__dirname, '..', 'src', 'contracts');
+const pathToBasicYulContract = path.join(pathToContracts, 'yul', contractYulFilename);
+const pathToBasicSolContract = path.join(pathToContracts, 'solidity', contractSolFilename);
+const pathToSolBinOutputFile = path.join(pathToOutputDir, contractSolFilename + binExtension);
+const pathToSolAsmOutputFile = path.join(pathToOutputDir, contractSolFilename + asmExtension);
+
+export const paths = {
+  outputDir: outputDir,
+  binExtension: binExtension,
+  asmExtension: asmExtension,
+  contractSolFilename: contractSolFilename,
+  contractYulFilename: contractYulFilename,
+  pathToOutputDir: pathToOutputDir,
+  pathToContracts: pathToContracts,
+  pathToBasicSolContract: pathToBasicSolContract,
+  pathToBasicYulContract: pathToBasicYulContract,
+  pathToSolBinOutputFile: pathToSolBinOutputFile,
+  pathToSolAsmOutputFile: pathToSolAsmOutputFile,
+};

--- a/revive-wasm/tests/wasm-tests/src/helper.ts
+++ b/revive-wasm/tests/wasm-tests/src/helper.ts
@@ -1,0 +1,29 @@
+import * as shell from 'shelljs';
+import * as fs from 'fs';
+
+interface CommandResult {
+    output: string;
+    exitCode: number;
+}
+
+export const executeCommand = (command: string): CommandResult  => {
+    const result  = shell.exec(command, {async: false});
+    return {
+        exitCode: result.code,
+        output: result.stdout.trim() || result.stderr.trim(),
+    };
+};
+
+export const isFolderExist = (folder: string): boolean  => {
+    return shell.test('-d', folder);
+};
+
+export const isFileExist = (pathToFileDir: string, fileName: string, fileExtension:string): boolean  => {     
+    return shell.ls(pathToFileDir).stdout.includes(fileName + fileExtension); 
+};
+
+export const isFileEmpty = (file: string): boolean  => {
+    if (fs.existsSync(file)) {
+        return (fs.readFileSync(file).length === 0);
+    } 
+};

--- a/revive-wasm/tests/wasm-tests/src/package.json
+++ b/revive-wasm/tests/wasm-tests/src/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/revive-wasm/tests/wasm-tests/src/tools.js
+++ b/revive-wasm/tests/wasm-tests/src/tools.js
@@ -1,0 +1,9 @@
+// Import the resolc module
+import ResolcModule from '../../../../target/wasm32-unknown-emscripten/release/resolc.js';
+
+// Provide the the resolc compiler
+export async function runResolc(resolc_options) {
+    const Resolc = await ResolcModule()
+    // Run the 'resolc' compiler with option '--version'
+    return Resolc.callMain(resolc_options);
+}

--- a/revive-wasm/tests/wasm-tests/tests/package.json
+++ b/revive-wasm/tests/wasm-tests/tests/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/revive-wasm/tests/wasm-tests/tests/resolc-options.test.js
+++ b/revive-wasm/tests/wasm-tests/tests/resolc-options.test.js
@@ -1,0 +1,21 @@
+// Run with:
+//     node --experimental-default-type=module testcase.js
+// (for Node version 18.20.3)
+
+import { runResolc } from '../src/tools.js'
+
+test('resolc handles \'--version\' option', async () => {
+    const retval = await runResolc(["--version"]);
+    expect(retval).toBe(0);
+})
+
+test('resolc handles \'--help\' option', async () => {
+    const retval = await runResolc(["--help"]);
+    expect(retval).toBe(0);
+
+})
+
+test('resolc handles a misspelled option', async () => {
+    const retval = await runResolc(["--hlp"]);
+    expect(retval).not.toBe(0);
+})

--- a/revive-wasm/tests/wasm-tests/tsconfig.json
+++ b/revive-wasm/tests/wasm-tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ES6",
+    "outDir": "./dist",
+  }
+}


### PR DESCRIPTION
Add basic test infrastructure for revive-wasm, intended to be run from the command line.
This depends on the revive-wasm build setup here: https://github.com/smiasojed/revive