### PR TITLE
Put llvm and compiler-rt build directories in one place.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ artifacts
 tmp
 package-lock.json
 /*.html
+/build


### PR DESCRIPTION
Adjust the llvm build script to put the llvm and compiler-rt build directories outside the llvm-project source directory. A new build directory 'build' at the toplevel of the revive directory is used instead. LLVM is built into 'build/llvm' and compiler-rt into 'build/compiler-rt'.

Adjust .gitignore to ignore the contents of the build directory.

This is intended to keep the build artifacts separate from the upstream sources and any changes made as part of the revive work.